### PR TITLE
Kddimitrov/fix framework add

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1703,13 +1703,14 @@ pbxProject.prototype.removeTarget = function(target, targetKey) {
         } else if (buildPhase.comment === buildPhaseNameForIsa("PBXFrameworksBuildPhase")) {
             section = this.hash.project.objects["PBXFrameworksBuildPhase"];
             var frameworkFiles = section[sectionUuid].files;
-            for (let q = 0; q < frameworkFiles.length; q++) {
-                var currentBuildFileUuid = frameworkFiles[q].value;
+            for (let currentBuildFile of frameworkFiles) {
+                var currentBuildFileUuid = currentBuildFile.value;
                 var fileRef = pbxBuildFileSection[currentBuildFileUuid].fileRef;
                 var stillReferenced = false;
                 for (var buildFileUuid in nonComments(pbxBuildFileSection)) {
                     if(pbxBuildFileSection[buildFileUuid].fileRef === fileRef && buildFileUuid !== currentBuildFileUuid){
                         stillReferenced = true;
+                        break;
                     }
                 }
 

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1677,10 +1677,13 @@ pbxProject.prototype.removeTargetsByProductType = function(targetProductType) {
 
 pbxProject.prototype.removeTarget = function(target, targetKey) {
     let files = [];
+    var pbxBuildFileSection = this.pbxBuildFileSection();
+    var fileReferenceSection = this.pbxFileReferenceSection();
 
     // iterate all buildPhases and collect all files that should be removed
     // remove the phase from the appropriate section
     var buildPhases = target["buildPhases"];
+
     for (let i = 0; i < buildPhases.length; i++) {
         var buildPhase = buildPhases[i];
         var sectionUuid = buildPhase.value;
@@ -1693,7 +1696,26 @@ pbxProject.prototype.removeTarget = function(target, targetKey) {
             files = files.concat(section[sectionUuid].files);
         } else if (buildPhase.comment === buildPhaseNameForIsa("PBXFrameworksBuildPhase")) {
             section = this.hash.project.objects["PBXFrameworksBuildPhase"];
-            files = files.concat(section[sectionUuid].files);
+            var frameworkFiles = section[sectionUuid].files;
+            for (let q = 0; q < frameworkFiles.length; q++) {
+                var currentBuildFileUuid = frameworkFiles[q].value;
+                var fileRef = pbxBuildFileSection[currentBuildFileUuid].fileRef;
+                var stillReferenced = false;
+                for (var buildFileUuid in nonComments(pbxBuildFileSection)) {
+                    if(pbxBuildFileSection[buildFileUuid].fileRef === fileRef && buildFileUuid !== currentBuildFileUuid){
+                        stillReferenced = true;
+                    }
+                }
+
+                if(!stillReferenced) {
+                    var frameworkFileRef = fileReferenceSection[fileRef];
+                    var fileToRemove = new pbxFile(unquote(frameworkFileRef.path), {basename: frameworkFileRef.name});
+                    fileToRemove.fileRef = fileRef;
+                    this.removeFromFrameworksPbxGroup(fileToRemove);
+                    removeItemAndCommentFromSectionByUuid(fileReferenceSection, fileRef);
+                }
+            }
+            files = files.concat(frameworkFiles);
         }
 
         removeItemAndCommentFromSectionByUuid(section, sectionUuid);
@@ -1734,12 +1756,10 @@ pbxProject.prototype.removeTarget = function(target, targetKey) {
     var productUuid = "";
 
     var productReferenceUuid = target.productReference;
-    var pbxBuildFileSection = this.pbxBuildFileSection();
-    var pbxBuildFileSectionNoComments = nonComments(pbxBuildFileSection);
 
     // the productReference is the uuid from the PBXFileReference Section, but we need the one in PBXBuildFile section
     // check the fileRef of all records until we find the product
-    for (var uuid in pbxBuildFileSectionNoComments) {
+    for (var uuid in nonComments(pbxBuildFileSection)) {
         if (this.pbxBuildFileSection()[uuid].fileRef == productReferenceUuid) {
             productUuid = uuid;
         }
@@ -1787,7 +1807,6 @@ pbxProject.prototype.removeTarget = function(target, targetKey) {
 
 
     //remove the product from the Products PBXGroup
-    var fileReferenceSection = this.pbxFileReferenceSection();
     var productReference = fileReferenceSection[productReferenceUuid];
     var productFile = new pbxFile(productReference.path);
     productFile.fileRef = productReferenceUuid;

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -669,27 +669,35 @@ pbxProject.prototype.removePbxGroup = function(groupName, path) {
     if (!groupKey) {
         return;
     }
+
+    this.removePbxGroupByKey(groupKey, path);
+}
+
+pbxProject.prototype.removePbxGroupByKey = function(groupKey, path) {
     var group = this.getPBXGroupByKey(groupKey) || this.getPBXVariantGroupByKey(groupKey)
+
+    if (!group) {
+        return;
+    }
  
     path = path || "";
-
     var children = group.children;
 
     for(i in children) {
         var file = new pbxFile($path.join(path, children[i].comment));
         file.fileRef = children[i].value;
         file.uuid = file.fileRef;
-        this.removePbxGroup(children[i].comment, $path.join(path, children[i].comment));
-        this.removeFromPbxFileReferenceSection(file);
+        this.removePbxGroupByKey(children[i].value, $path.join(path, children[i].comment));
+        this.removeFromPbxFileReferenceSectionByUuid(children[i].value);
         this.removeFromPbxBuildFileSection(file);
         this.removeFromPbxSourcesBuildPhase(file);
     }
 
     var mainGroup = this.findMainPbxGroup();
     if(mainGroup) {
-        var mainGroupChildren = this.findMainPbxGroup().children, i;
+        var mainGroupChildren = mainGroup.children, i;
         for(i in mainGroupChildren) {
-            if (mainGroupChildren[i].comment == groupName) {
+            if (mainGroupChildren[i].value == groupKey) {
                 mainGroupChildren.splice(i, 1);
             }
         }
@@ -702,15 +710,7 @@ pbxProject.prototype.removePbxGroup = function(groupName, path) {
         section = this.hash.project.objects['PBXGroup'];
     }
 
-    for (key in section) {
-        // only look for comments
-        if (!COMMENT_KEY.test(key)) continue;
-
-        if (section[key] == groupName) {
-            itemKey = key.split(COMMENT_KEY)[0];
-            delete section[itemKey];
-        }
-    }
+    removeItemAndCommentFromSectionByUuid(section, groupKey);
 }
 
 pbxProject.prototype.addToPbxProjectSection = function(target) {
@@ -757,6 +757,12 @@ pbxProject.prototype.removeFromPbxFileReferenceSection = function(file) {
     }
 
     return file;
+}
+
+pbxProject.prototype.removeFromPbxFileReferenceSectionByUuid = function(fileUuid) {
+    var section = this.pbxFileReferenceSection();
+
+    removeItemAndCommentFromSectionByUuid(section, fileUuid);
 }
 
 pbxProject.prototype.addToXcVersionGroupSection = function(file) {

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -641,7 +641,7 @@ function handleLocalization(files, pbxGroup, srcRootPath, opt) {
                 if(parsedRegionFilePath.ext === ".storyboard") {
                     storyboardNames[parsedRegionFilePath.name] = true;
                 }
-                fileRegions = allNames[parsedRegionFilePath.name] = allNames[parsedRegionFilePath.name] || [];
+                var fileRegions = allNames[parsedRegionFilePath.name] = allNames[parsedRegionFilePath.name] || [];
                 fileRegions.push(regionName);
                 region[regionFileName] = $path.join(filePath, regionFilePath);
             }
@@ -649,14 +649,14 @@ function handleLocalization(files, pbxGroup, srcRootPath, opt) {
     }
 
     for (var name in allNames) {
-        fileRegions = allNames[name]
+        var fileRegionsForName = allNames[name]
         var variantGroupName = storyboardNames[name] ? name + ".storyboard" : name + ".strings";
 
         var variantGroup = this.addLocalizationVariantGroup(variantGroupName, { target: opt.target, skipAddToResourcesGroup: true });
         pbxGroup.children.push(pbxGroupChild(variantGroup));
-        for (let k = 0; k < fileRegions.length; k++) {
-            var file = regions[fileRegions[k]][name];
-            var refFile = new pbxFile($path.relative(srcRootPath, file), {basename: fileRegions[k]});
+        for (let k = 0; k < fileRegionsForName.length; k++) {
+            var file = regions[fileRegionsForName[k]][name];
+            var refFile = new pbxFile($path.relative(srcRootPath, file), {basename: fileRegionsForName[k]});
             refFile.fileRef = this.generateUuid();
             this.addToPbxFileReferenceSection(refFile);
             this.addToPbxVariantGroup(refFile, variantGroup.fileRef);


### PR DESCRIPTION
When removing a target if it holds the only reference to the framework it should remove it from the PbxFileReference section and projects Framework PbxGroup.

When removing the variant group, the children name is very likely to collide in FileReference section and the wrong reference is removed. And when removing a group if there is a group collision more than one group will be removed.

All this issues are addressed in this PR.