### PR TITLE
Kddimitrov/fix add framework

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -338,14 +338,19 @@ pbxProject.prototype.addFramework = function(fpath, opt) {
     file.fileRef = this.generateUuid();
     file.target = opt ? opt.target : undefined;
 
-    if (this.hasFile(file.path)) return false;
-
-    this.addToPbxBuildFileSection(file);        // PBXBuildFile
-    this.addToPbxFileReferenceSection(file);    // PBXFileReference
-    this.addToFrameworksPbxGroup(file);         // PBXGroup
+    var fileReference = this.hasFile(file.path);
+    if (fileReference) {
+        var key = this.getFileKey(file.path);
+        file.fileRef = key;
+    } else {
+        this.addToPbxFileReferenceSection(file);    // PBXFileReference
+        this.addToFrameworksPbxGroup(file);         // PBXGroup
+    }
 
     if (link) {
-      this.addToPbxFrameworksBuildPhase(file);    // PBXFrameworksBuildPhase
+        if(this.addToPbxFrameworksBuildPhase(file)) {   // PBXFrameworksBuildPhase)
+            this.addToPbxBuildFileSection(file);        // PBXBuildFile
+        }
     }
 
     if (customFramework) {
@@ -357,13 +362,13 @@ pbxProject.prototype.addFramework = function(fpath, opt) {
 
           embeddedFile.uuid = this.generateUuid();
           embeddedFile.fileRef = file.fileRef;
+          embeddedFile.target = file.target;
 
-          //keeping a separate PBXBuildFile entry for Embed Frameworks
-          this.addToPbxBuildFileSection(embeddedFile);        // PBXBuildFile
-
-          this.addToPbxEmbedFrameworksBuildPhase(embeddedFile); // PBXCopyFilesBuildPhase
-
-          return embeddedFile;
+            if(this.addToPbxEmbedFrameworksBuildPhase(embeddedFile)) {  // PBXCopyFilesBuildPhase
+                //keeping a separate PBXBuildFile entry for Embed Frameworks
+                this.addToPbxBuildFileSection(embeddedFile);            // PBXBuildFile
+                return embeddedFile;
+            }
         }
     }
 
@@ -856,10 +861,25 @@ pbxProject.prototype.removeFromFrameworksPbxGroup = function(file) {
     }
 }
 
+function hasReferenceInPbxBuildFile(buildFileReferences, fileReference) {
+    var buildFileSection = this.pbxBuildFileSection();
+    for(let buildFileReference of buildFileReferences) {
+        if(buildFileSection[buildFileReference.value] && buildFileSection[buildFileReference.value].fileRef === fileReference.fileRef){
+            return true;
+        }
+    }
+}
+
 pbxProject.prototype.addToPbxEmbedFrameworksBuildPhase = function (file) {
     var sources = this.pbxEmbedFrameworksBuildPhaseObj(file.target);
+
     if (sources) {
+        if(hasReferenceInPbxBuildFile.call(this, sources.files, file)){
+            return false;
+        }
+
         sources.files.push(pbxBuildPhaseObj(file));
+        return true;
     }
 }
 
@@ -933,7 +953,15 @@ pbxProject.prototype.removeFromPbxResourcesBuildPhase = function(file) {
 
 pbxProject.prototype.addToPbxFrameworksBuildPhase = function(file) {
     var sources = this.pbxFrameworksBuildPhaseObj(file.target);
-    sources.files.push(pbxBuildPhaseObj(file));
+
+    if (sources) {
+        if (hasReferenceInPbxBuildFile.call(this, sources.files, file)) {
+            return false;
+        }
+
+        sources.files.push(pbxBuildPhaseObj(file));
+        return true;
+    }
 }
 
 pbxProject.prototype.removeFromPbxFrameworksBuildPhase = function(file) {
@@ -1353,8 +1381,10 @@ pbxProject.prototype.addToFrameworkSearchPaths = function(file) {
             || buildSettings['FRAMEWORK_SEARCH_PATHS'] === INHERITED) {
             buildSettings['FRAMEWORK_SEARCH_PATHS'] = [INHERITED];
         }
-
-        buildSettings['FRAMEWORK_SEARCH_PATHS'].push(searchPathForFile(file, this));
+        var searchPath = searchPathForFile(file, this);
+        if(buildSettings['FRAMEWORK_SEARCH_PATHS'].indexOf(searchPath) < 0){
+            buildSettings['FRAMEWORK_SEARCH_PATHS'].push(searchPath);
+        }
     }
 }
 
@@ -1559,6 +1589,19 @@ pbxProject.prototype.hasFile = function(filePath) {
         file = files[id];
         if (file.path == filePath || file.path == ('"' + filePath + '"')) {
             return file;
+        }
+    }
+
+    return false;
+}
+
+pbxProject.prototype.getFileKey = function(filePath) {
+    var files = nonComments(this.pbxFileReferenceSection()),
+        file, id;
+    for (id in files) {
+        file = files[id];
+        if (file.path == filePath || file.path == ('"' + filePath + '"')) {
+            return id;
         }
     }
 

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -348,8 +348,11 @@ pbxProject.prototype.addFramework = function(fpath, opt) {
     }
 
     if (link) {
-        if(this.addToPbxFrameworksBuildPhase(file)) {   // PBXFrameworksBuildPhase)
+        const buildFileUuid = this.addToPbxFrameworksBuildPhase(file);
+        if(buildFileUuid === file.uuid) {   // PBXFrameworksBuildPhase)
             this.addToPbxBuildFileSection(file);        // PBXBuildFile
+        } else {
+            file.uuid = buildFileUuid;
         }
     }
 
@@ -357,18 +360,21 @@ pbxProject.prototype.addFramework = function(fpath, opt) {
         this.addToFrameworkSearchPaths(file);
 
         if (embed) {
-          opt.embed = embed;
-          var embeddedFile = new pbxFile(fpath, opt);
+            opt.embed = embed;
+            var embeddedFile = new pbxFile(fpath, opt);
 
-          embeddedFile.uuid = this.generateUuid();
-          embeddedFile.fileRef = file.fileRef;
-          embeddedFile.target = file.target;
-
-            if(this.addToPbxEmbedFrameworksBuildPhase(embeddedFile)) {  // PBXCopyFilesBuildPhase
+            embeddedFile.uuid = this.generateUuid();
+            embeddedFile.fileRef = file.fileRef;
+            embeddedFile.target = file.target;
+            const embedBuildFileUuid = this.addToPbxEmbedFrameworksBuildPhase(embeddedFile);
+            if(embedBuildFileUuid === embeddedFile.uuid) {  // PBXCopyFilesBuildPhase
                 //keeping a separate PBXBuildFile entry for Embed Frameworks
                 this.addToPbxBuildFileSection(embeddedFile);            // PBXBuildFile
-                return embeddedFile;
+            } else {
+                embeddedFile.uuid = embedBuildFileUuid;
             }
+
+            return embeddedFile;
         }
     }
 
@@ -861,11 +867,11 @@ pbxProject.prototype.removeFromFrameworksPbxGroup = function(file) {
     }
 }
 
-function hasReferenceInPbxBuildFile(buildFileReferences, fileReference) {
+function getReferenceInPbxBuildFile(buildFileReferences, fileReference) {
     var buildFileSection = this.pbxBuildFileSection();
     for(let buildFileReference of buildFileReferences) {
         if(buildFileSection[buildFileReference.value] && buildFileSection[buildFileReference.value].fileRef === fileReference.fileRef){
-            return true;
+            return buildFileReference.value;
         }
     }
 }
@@ -874,12 +880,13 @@ pbxProject.prototype.addToPbxEmbedFrameworksBuildPhase = function (file) {
     var sources = this.pbxEmbedFrameworksBuildPhaseObj(file.target);
 
     if (sources) {
-        if(hasReferenceInPbxBuildFile.call(this, sources.files, file)){
-            return false;
+        var referenceUuid = getReferenceInPbxBuildFile.call(this, sources.files, file)
+        if(referenceUuid){
+            return referenceUuid;
         }
 
         sources.files.push(pbxBuildPhaseObj(file));
-        return true;
+        return file.uuid;
     }
 }
 
@@ -955,12 +962,13 @@ pbxProject.prototype.addToPbxFrameworksBuildPhase = function(file) {
     var sources = this.pbxFrameworksBuildPhaseObj(file.target);
 
     if (sources) {
-        if (hasReferenceInPbxBuildFile.call(this, sources.files, file)) {
-            return false;
+        var frameworkBuildUuid = getReferenceInPbxBuildFile.call(this, sources.files, file);
+        if (frameworkBuildUuid) {
+            return frameworkBuildUuid;
         }
 
         sources.files.push(pbxBuildPhaseObj(file));
-        return true;
+        return file.uuid;
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "nativescript-dev-xcode",
   "description": "parser for xcodeproj/project.pbxproj files",
   "main": "index.js",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "repository": {
     "url": "https://github.com/NativeScript/nativescript-dev-xcode.git"
   },

--- a/test/addFramework.js
+++ b/test/addFramework.js
@@ -188,10 +188,20 @@ exports.addFramework = {
         test.done();
     },
     'duplicate entries': {
-        'should return false': function (test) {
+        'should return same build file': function (test) {
             var newFile = proj.addFramework('libsqlite3.dylib');
+            var sameFile = proj.addFramework('libsqlite3.dylib');
 
-            test.ok(!proj.addFramework('libsqlite3.dylib'));
+            test.equal(newFile.uuid, sameFile.uuid);
+            test.equal(newFile.fileRef, sameFile.fileRef);
+            test.done();
+        },
+        'should return different build file with same ref for different target': function (test) {
+            var newFile = proj.addFramework('libsqlite3.dylib');
+            var differentFile = proj.addFramework('libsqlite3.dylib', { target: "1D6058900D05DD3D006BFB54"});
+
+            test.notEqual(newFile.uuid, differentFile.uuid);
+            test.equal(newFile.fileRef, differentFile.fileRef);
             test.done();
         }
     },

--- a/test/fixtures/full-project.json
+++ b/test/fixtures/full-project.json
@@ -564,7 +564,15 @@
           ],
           "runOnlyForDeploymentPostprocessing": 0
         },
-        "1D60588F0D05DD3D006BFB54_comment": "Frameworks"
+        "1D60588F0D05DD3D006BFB54_comment": "Frameworks",
+        "2D60588F0D05DD3D006BFB55": {
+          "isa": "PBXFrameworksBuildPhase",
+          "buildActionMask": 2147483647,
+          "files": [
+          ],
+          "runOnlyForDeploymentPostprocessing": 0
+        },
+        "2D60588F0D05DD3D006BFB55_comment": "Frameworks"
       },
       "PBXGroup": {
         "080E96DDFE201D6D7F000001": {
@@ -866,7 +874,7 @@
               "comment": "Sources"
             },
             {
-              "value": "1D60588F0D05DD3D006BFB54",
+              "value": "2D60588F0D05DD3D006BFB55",
               "comment": "Frameworks"
             }
           ],


### PR DESCRIPTION
In previous implementation adding same SDK framework to two different targets, would result in only one target with the framework. The other one would have been skipped.

Now we check on every level of adding the framework (adding file reference, adding to source build phase, adding to copy files phase - embed) if we are going to create duplicates and if not we add the record.

Breaking change: If framework was already added we will return the existing PBXBuildFile reference instead of false.