### PR TITLE
fix: add quotes for scoped packages containing "@"

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -550,7 +550,7 @@ pbxProject.prototype.addPbxGroup = function (filePathsArray, name, path, sourceT
     var groups = this.hash.project.objects['PBXGroup'],
         pbxGroupUuid = opt.uuid || this.generateUuid(),
         commentKey = f("%s_comment", pbxGroupUuid),
-        groupName = name.indexOf(" ") >= 0 && name[0] !== `"` ? `"${name}"` : name,
+        groupName = (name.indexOf(" ") >= 0 || name.indexOf("@") >= 0) && name[0] !== `"` ? `"${name}"` : name,
         pbxGroup = {
             isa: 'PBXGroup',
             children: [],


### PR DESCRIPTION
When generating PbxGroup the name might contain "@" (ex. `@nativescript/core`). In this case we should add quotes to the string.