### PR TITLE
fix: don't remove groups by name as multiple can coexist

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -542,11 +542,6 @@ pbxProject.prototype.findMainPbxGroup = function () {
 pbxProject.prototype.addPbxGroup = function (filePathsArray, name, path, sourceTree, opt) {
     opt = opt || {};
     var srcRootPath = $path.dirname($path.dirname(this.filepath));
-    var oldGroup = this.pbxGroupByName(name);
-    if (oldGroup) {
-        this.removePbxGroup(name, path);
-    }
-
     var groups = this.hash.project.objects['PBXGroup'],
         pbxGroupUuid = opt.uuid || this.generateUuid(),
         commentKey = f("%s_comment", pbxGroupUuid),


### PR DESCRIPTION
Removing groups by name will remove valid groups in case there are multiple groups with the same name, ie. the same folder name as part of multiple different folders.

```
platforms/ios/src/
  Foo/
    Foo1_Files/
      Resources/ <bunch of images>
      Storyboard/
        Foo1.storyboard
    Foo2_Files/
      Resources/ <bunch of images>
      Storyboard/
        Foo2.storyboard
```

`Foo1_Files/Resources` and `Foo1_Files/Storyboard` would be removed causing these resources to be missing.
