### PR TITLE
fix: ensure that PbxGroups are not duplicated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ node_modules/*
 .DS_Store
 npm-debug.log
 package-lock.json
-
+.ns-build-pbxgroup-data.json
 *.tgz

--- a/lib/guidMapper.js
+++ b/lib/guidMapper.js
@@ -1,0 +1,52 @@
+const fs = require('fs');
+const path = require('path');
+
+function guidMapper(filePath) {
+  this.filePath = filePath;
+  this.data = this.loadFromFile();
+}
+
+guidMapper.prototype.loadFromFile = function () {
+  try {
+    const rawData = fs.readFileSync(this.filePath, 'utf8');
+    return JSON.parse(rawData);
+  } catch (error) {
+    // If file doesn't exist or there's an error parsing it, initialize with an empty object.
+    return {};
+  }
+};
+
+guidMapper.prototype.writeFileSync = function () {
+  const jsonData = JSON.stringify(this.data, null, 2);
+  fs.writeFileSync(this.filePath, jsonData, 'utf8');
+};
+
+guidMapper.prototype.addEntry = function (guid, path, name) {
+  if(!!guid && !! path && !!name){
+    this.data[guid] = { path: path, name: name };
+  }
+};
+
+guidMapper.prototype.removeEntry = function (guid) {
+  if (this.data[guid]) {
+    delete this.data[guid];
+  } 
+};
+
+guidMapper.prototype.getEntries = function () {
+  return this.data;
+};
+
+guidMapper.prototype.findEntryGuid = function (name, path) {
+  for (const guid in this.data) {
+    if (this.data.hasOwnProperty(guid)) {
+      const entry = this.data[guid];
+      if (entry.path === path && entry.name === name) {
+        return guid;
+      }
+    }
+  }
+  return null;
+};
+
+module.exports = guidMapper;

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -35,7 +35,8 @@ var util = require('util'),
     isEntitlementFileType = constants.isEntitlementFileType,
     isAssetFileType = constants.isAssetFileType,
     isPlistFileType = constants.isPlistFileType,
-    isModuleMapFileType = constants.isModuleMapFileType;
+    isModuleMapFileType = constants.isModuleMapFileType,
+    guidMapper = require('./guidMapper');
 
 function pbxProject(filename) {
     if (!(this instanceof pbxProject))
@@ -74,6 +75,10 @@ pbxProject.prototype.parseSync = function() {
 }
 
 pbxProject.prototype.writeSync = function(options) {
+    if(this.pbxGroupTracker){
+        this.pbxGroupTracker.writeFileSync();
+    }
+
     this.writer = new pbxWriter(this.hash, options);
     return this.writer.writeSync();
 }
@@ -538,10 +543,27 @@ pbxProject.prototype.findMainPbxGroup = function () {
 
     return null;
 }
+pbxProject.prototype.getPbxGroupTracker = function (path) {
+
+    if(!this.pbxGroupTracker){
+        this.pbxGroupTracker = new guidMapper($path.join(path, '.ns-build-pbxgroup-data.json'));
+    }
+
+    return this.pbxGroupTracker;
+}
 
 pbxProject.prototype.addPbxGroup = function (filePathsArray, name, path, sourceTree, opt) {
     opt = opt || {};
     var srcRootPath = $path.dirname($path.dirname(this.filepath));
+    
+    var existingGroupId = this.getPbxGroupTracker(srcRootPath).findEntryGuid(name, path);
+    if(existingGroupId){
+        if(this.getPBXGroupByKey(existingGroupId)){
+            this.removePbxGroupByKey(existingGroupId, path);
+        }  
+        this.pbxGroupTracker.removeEntry(existingGroupId);
+    }
+
     var groups = this.hash.project.objects['PBXGroup'],
         pbxGroupUuid = opt.uuid || this.generateUuid(),
         commentKey = f("%s_comment", pbxGroupUuid),
@@ -559,6 +581,9 @@ pbxProject.prototype.addPbxGroup = function (filePathsArray, name, path, sourceT
     if(!opt.filesRelativeToProject) {
         pbxGroup.path = path;
     }
+
+    // save to group to the tracker
+    this.pbxGroupTracker.addEntry(pbxGroupUuid, path, name);
 
     for (var key in fileReferenceSection) {
         // only look for comments

--- a/test/guidMapper.js
+++ b/test/guidMapper.js
@@ -1,0 +1,69 @@
+var guidMapper = require('../lib/guidMapper');
+const fs = require('fs');
+const $uuid = require('uuid');
+const TEST_FILE_NAME = 'test/.ns-build-pbxgroup-data.json';
+const goodGUID = $uuid.v4();
+const goodName = "goodName";
+const badName = 'badName';
+const goodPath = "goodPath";
+const badPath = "badPath";
+exports.setUp = function(callback) {
+    if(fs.existsSync(TEST_FILE_NAME)){
+        fs.rmSync(TEST_FILE_NAME);
+    }
+    callback();
+}
+exports.tearDown = function(callback) {
+    if(fs.existsSync(TEST_FILE_NAME)){
+        fs.rmSync(TEST_FILE_NAME);
+    }
+    callback();
+}
+function addTestData(){
+    var mapper = new guidMapper(TEST_FILE_NAME);
+        mapper.addEntry(goodGUID, goodPath, goodName);
+        mapper.writeFileSync();
+}
+exports.operations = {
+    'should be able to add to map': function(test) {
+        var mapper = new guidMapper(TEST_FILE_NAME);
+        mapper.addEntry(goodGUID, goodPath, goodName);
+        mapper.writeFileSync();
+        mapper = new guidMapper(TEST_FILE_NAME);
+        const result = mapper.findEntryGuid(goodName, goodPath);
+        
+        test.ok(result === goodGUID)
+        test.done();
+    },
+    'should not match only on name': function(test) {
+        addTestData();
+        var mapper = new guidMapper(TEST_FILE_NAME);
+       
+        const result = mapper.findEntryGuid(goodName, badPath);
+        
+        test.ok(result === null)
+        test.done();
+    },
+    'should not match only on path': function(test) {
+        addTestData();
+        var mapper = new guidMapper(TEST_FILE_NAME);
+       
+        const result = mapper.findEntryGuid(badName, goodPath);
+        
+        test.ok(result === null)
+        test.done();
+    },
+    'can remove': function(test) {
+        addTestData();
+        var mapper = new guidMapper(TEST_FILE_NAME);
+        mapper.removeEntry(goodGUID);
+        var result = mapper.findEntryGuid(goodName, goodPath);
+        
+        test.ok(result === null);
+        mapper.writeFileSync();
+        result = mapper.findEntryGuid(goodName, goodPath);
+        test.ok(result === null)
+
+        test.done();
+    }
+}

--- a/test/pbxProject.js
+++ b/test/pbxProject.js
@@ -433,3 +433,20 @@ exports['addToPbxFileReferenceSection'] = {
     }
 }
 
+
+exports['addPbxGroup'] = {
+    'should not add the same group twice': function (test) {
+        var newProj = new pbx('test/parser/projects/group.pbxproj');
+        newProj.parse(function (err, hash) {
+            this.hash.project.objects['PBXVariantGroup']={};
+            var group1 = newProj.addPbxGroup(['test/somefile'], "TestGroup", "test/somepath", null, null);
+            var group2 = newProj.addPbxGroup(['test/somefile'], "TestGroup", "test/somepath", null, null);
+            test.equal(newProj.getPBXGroupByKey(group1.uuid), null);
+            test.equal(newProj.getPBXGroupByKey(group2.uuid).name, "TestGroup");
+            test.equal(newProj.getPbxGroupTracker().getEntries().hasOwnProperty(group1.uuid), false);
+            test.equal(newProj.getPbxGroupTracker().getEntries().hasOwnProperty(group2.uuid), true);           
+        
+        test.done();
+        });
+    }
+}


### PR DESCRIPTION
This tracks the PbxGroups that are created, to ensure that duplicates are not created while also allowing for the scenario as described in #15 addressing nativescript/nativescript-cli#5765.

It tracks the groups in an external file so that you can edit the project in XCode and still maintain the link.