### PR TITLE
fix: last fix for symlinks

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -613,7 +613,14 @@ pbxProject.prototype.addPbxGroup = function (filePathsArray, name, path, sourceT
         if(opt.target) {
             file.target = opt.target;
         }
-        if (fs.existsSync(filePath) && (fs.lstatSync(filePath).isDirectory() || fs.lstatSync(filePath).isSymbolicLink()) && !isAssetFileType(file.lastKnownFileType)) {
+        // if the file is a symLink, isDirectory() returns false
+        // but isFile() too so we need to see if the realPath is a directory
+        const exists = fs.existsSync(filePath);
+        const stats = exists && fs.lstatSync(filePath);
+        const isSymlink = exists && fs.lstatSync(filePath).isSymbolicLink();
+        let symRealPath = isSymlink && fs.realpathSync(filePath);
+        const isRealDir = stats && stats.isDirectory() || (isSymlink && fs.lstatSync(symRealPath).isDirectory());
+        if (exists && isRealDir && !isAssetFileType(file.lastKnownFileType)) {
             if($path.extname(filePath) === ".lproj") {
                 continue;
             }


### PR DESCRIPTION
The last patch was not working with files symlinks, only directories. Now it works with both