### PR TITLE
fix: optional groups when using embedding against host projects

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1566,7 +1566,11 @@ pbxProject.prototype.addToHeaderSearchPaths = function(file, productName) {
             buildSettings['HEADER_SEARCH_PATHS'] = [INHERITED];
         }
 
-        buildSettings['HEADER_SEARCH_PATHS'].push(searchPathForFile(file, this));
+        // Check if the search path is already in the HEADER_SEARCH_PATHS and add it if it's not.
+        const searchPath = searchPathForFile(file, this);
+        if (buildSettings['HEADER_SEARCH_PATHS'].indexOf(searchPath) < 0) {
+            buildSettings['HEADER_SEARCH_PATHS'].push(searchPath);
+        }
     }
 }
 

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -2143,7 +2143,7 @@ function correctForFrameworksPath(file, project) {
 function correctForPath(file, project, group) {
     var r_group_dir = new RegExp('^' + group + '[\\\\/]');
 
-    if (project.pbxGroupByName(group).path)
+    if (project.pbxGroupByName(group)?.path)
         file.path = file.path.replace(r_group_dir, '');
 
     return file;
@@ -2393,7 +2393,7 @@ pbxProject.prototype.getPBXGroupByKey = function(key) {
 };
 
 pbxProject.prototype.getPBXVariantGroupByKey = function(key) {
-    return this.hash.project.objects['PBXVariantGroup'][key];
+    return this.hash.project.objects['PBXVariantGroup']?.[key];
 };
 
 

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -885,7 +885,7 @@ pbxProject.prototype.removeFromResourcesPbxGroup = function(file) {
 pbxProject.prototype.addToFrameworksPbxGroup = function(file) {
     var pluginsGroup = this.pbxGroupByName('Frameworks');
     if (!pluginsGroup) {
-        this.addPbxGroup([file.path], 'Frameworks');
+        this.addPbxGroup([file.path], 'Frameworks', 'Frameworks', null, { isMain: true, filesRelativeToProject: true});
     } else {
         pluginsGroup.children.push(pbxGroupChild(file));
     }

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1320,7 +1320,13 @@ pbxProject.prototype.pbxResourcesBuildPhaseObj = function(target) {
 }
 
 pbxProject.prototype.pbxFrameworksBuildPhaseObj = function(target) {
-    return this.buildPhaseObject('PBXFrameworksBuildPhase', 'Frameworks', target);
+    let buildPhase = this.buildPhaseObject('PBXFrameworksBuildPhase', 'Frameworks', target);
+    if (!buildPhase) {
+        // Create Frameworks phase in parent target
+        const phase = this.addBuildPhase([], 'PBXFrameworksBuildPhase', 'Frameworks', target);
+        buildPhase = phase.buildPhase;
+    }
+    return buildPhase;
 }
 
 pbxProject.prototype.pbxEmbedFrameworksBuildPhaseObj = function (target) {

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1324,7 +1324,13 @@ pbxProject.prototype.pbxFrameworksBuildPhaseObj = function(target) {
 }
 
 pbxProject.prototype.pbxEmbedFrameworksBuildPhaseObj = function (target) {
-    return this.buildPhaseObject('PBXCopyFilesBuildPhase', 'Embed Frameworks', target);
+    let buildPhase = this.buildPhaseObject('PBXCopyFilesBuildPhase', 'Embed Frameworks', target);
+    if (!buildPhase) {
+        // Create CopyFiles phase in parent target
+        const phase = this.addBuildPhase([], 'PBXCopyFilesBuildPhase', 'Embed Frameworks', target);
+        buildPhase = phase.buildPhase;
+    }
+    return buildPhase;
 };
 
 // Find Build Phase from group/target

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -578,7 +578,7 @@ pbxProject.prototype.addPbxGroup = function (filePathsArray, name, path, sourceT
         filePathToReference = {};
 
     //path is mandatory only for the main group
-    if(!opt.filesRelativeToProject) {
+    if(!opt.filesRelativeToProject && path) {
         pbxGroup.path = path;
     }
 

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1323,7 +1323,7 @@ pbxProject.prototype.pbxFrameworksBuildPhaseObj = function(target) {
     let buildPhase = this.buildPhaseObject('PBXFrameworksBuildPhase', 'Frameworks', target);
     if (!buildPhase) {
         // Create Frameworks phase in parent target
-        const phase = this.addBuildPhase([], 'PBXFrameworksBuildPhase', 'Frameworks', target);
+        const phase = this.addBuildPhase([], 'PBXFrameworksBuildPhase', 'Frameworks', target, 'frameworks');
         buildPhase = phase.buildPhase;
     }
     return buildPhase;
@@ -1333,7 +1333,7 @@ pbxProject.prototype.pbxEmbedFrameworksBuildPhaseObj = function (target) {
     let buildPhase = this.buildPhaseObject('PBXCopyFilesBuildPhase', 'Embed Frameworks', target);
     if (!buildPhase) {
         // Create CopyFiles phase in parent target
-        const phase = this.addBuildPhase([], 'PBXCopyFilesBuildPhase', 'Embed Frameworks', target);
+        const phase = this.addBuildPhase([], 'PBXCopyFilesBuildPhase', 'Embed Frameworks', target, 'frameworks');
         buildPhase = phase.buildPhase;
     }
     return buildPhase;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "nativescript-dev-xcode",
   "description": "parser for xcodeproj/project.pbxproj files",
   "main": "index.js",
-  "version": "0.7.1-alpha.1",
+  "version": "0.7.1-alpha.2",
   "files": [
     "lib",
     "!lib/parser/pbxproj.pegjs"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "nativescript-dev-xcode",
   "description": "parser for xcodeproj/project.pbxproj files",
   "main": "index.js",
-  "version": "0.7.1-alpha.2",
+  "version": "0.7.1-alpha.3",
   "files": [
     "lib",
     "!lib/parser/pbxproj.pegjs"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "nativescript-dev-xcode",
   "description": "parser for xcodeproj/project.pbxproj files",
   "main": "index.js",
-  "version": "0.7.1-alpha.3",
+  "version": "0.7.1-alpha.4",
   "files": [
     "lib",
     "!lib/parser/pbxproj.pegjs"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "nativescript-dev-xcode",
   "description": "parser for xcodeproj/project.pbxproj files",
   "main": "index.js",
-  "version": "0.7.0",
+  "version": "0.7.1-alpha.1",
   "files": [
     "lib",
     "!lib/parser/pbxproj.pegjs"


### PR DESCRIPTION
- When embedding NativeScript into other platform host projects, group setup may be different. These cases can just be optionally ignored.