### PR TITLE
fix: prevent error when adding framework from build product dir

### DIFF
--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -131,7 +131,8 @@ function pbxFile(filepath, opt) {
         // dont delete path as it is used after
         // delete this.path;
         delete this.lastKnownFileType;
-        delete this.group;
+        // dont delete group as it is used after
+        // delete this.group;
         delete this.defaultEncoding;
     }
 

--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -128,7 +128,8 @@ function pbxFile(filepath, opt) {
     if (opt.explicitFileType) {
         this.explicitFileType = opt.explicitFileType;
         this.basename = this.basename + '.' + defaultExtension(this);
-        delete this.path;
+        // dont delete path as it is used after
+        // delete this.path;
         delete this.lastKnownFileType;
         delete this.group;
         delete this.defaultEncoding;


### PR DESCRIPTION
I need this for an upcoming PR on the cli to create much more complex watch projects
Without this it would crash if you define `explicitFileType` 