### PR TITLE
fix: addTarget allow different productType

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1700,11 +1700,12 @@ pbxProject.prototype.getFileKey = function(filePath) {
     return false;
 }
 
-pbxProject.prototype.addTarget = function(name, type, subfolder, parentTarget) {
+pbxProject.prototype.addTarget = function(name, type, subfolder, parentTarget, productTargetType) {
 
     // Setup uuid and name of new target
     var targetUuid = this.generateUuid(),
         targetType = type,
+        productTargetType = productTargetType || targetType,
         targetSubfolder = subfolder || name,
         targetName = name.trim();
 
@@ -1753,7 +1754,7 @@ pbxProject.prototype.addTarget = function(name, type, subfolder, parentTarget) {
 
     // Product: Create
     var productName = targetName,
-        productType = producttypeForTargettype(targetType),
+        productType = producttypeForTargettype(productTargetType),
         productFileType = filetypeForProducttype(productType),
         productFile = this.addProductFile(productName, { group: 'Copy Files', 'target': targetUuid, 'explicitFileType': productFileType}),
         productFileName = productFile.basename;
@@ -1781,10 +1782,10 @@ pbxProject.prototype.addTarget = function(name, type, subfolder, parentTarget) {
     // Target: Add to PBXNativeTarget section
     this.addToPbxNativeTargetSection(target);
 
-    if (targetType === 'app_extension' || targetType === 'watch_extension' || targetType === 'watch_app') {
-        const isWatchApp = targetType === 'watch_app';
+    if (productTargetType === 'app_extension' || productTargetType === 'watch_extension' || productTargetType === 'watch_app') {
+        const isWatchApp = productTargetType === 'watch_app';
         const copyTargetUuid = parentTarget || this.getFirstTarget().uuid;
-        const phaseComment = targetType === 'watch_app' ? 'Embed Watch Content' : 'Copy Files';
+        const phaseComment = productTargetType === 'watch_app' ? 'Embed Watch Content' : 'Copy Files';
         let destination;
 
         if(isWatchApp) {
@@ -1792,7 +1793,7 @@ pbxProject.prototype.addTarget = function(name, type, subfolder, parentTarget) {
         }
 
         // Create CopyFiles phase in parent target
-        this.addBuildPhase([], 'PBXCopyFilesBuildPhase', phaseComment, copyTargetUuid,  targetType, destination);
+        this.addBuildPhase([], 'PBXCopyFilesBuildPhase', phaseComment, copyTargetUuid,  productTargetType, destination);
 
         // Add product to CopyFiles phase
         this.addToPbxCopyfilesBuildPhase(productFile, phaseComment, copyTargetUuid);


### PR DESCRIPTION
It seems when you create watchapp in xcode it creates an "application" and not a "watch_app" target.
So when trying to simulate with nativescript-dev-xcode, creating an "application" would then not embed the watch app.
being able to specify a different product target type (watch_app) allows to fix that issue.

This PR is needed for the coming cli PR